### PR TITLE
test: Lower Consistently() duration from 10s to 1s

### DIFF
--- a/controllers/drcluster_controller_test.go
+++ b/controllers/drcluster_controller_test.go
@@ -137,7 +137,7 @@ func drclusterConditionExpect(
 	case false:
 		Eventually(testFunc, timeout, interval).Should(matchElements)
 	case true:
-		Consistently(testFunc, timeout, interval).Should(matchElements)
+		Consistently(testFunc).Should(matchElements)
 	}
 
 	// TODO: Validate finaliziers and labels

--- a/controllers/drplacementcontrol_controller_test.go
+++ b/controllers/drplacementcontrol_controller_test.go
@@ -1057,7 +1057,7 @@ func ensureDRPolicyIsNotDeleted(drpc *rmn.DRPlacementControl) {
 		err := apiReader.Get(context.TODO(), types.NamespacedName{Name: name}, drpolicy)
 		// TODO: Technically we need to Expect deletion TS is non-zero as well here!
 		return err == nil
-	}, timeout, interval).Should(BeTrue(), "DRPolicy deleted prematurely, with active DRPC references")
+	}).Should(BeTrue(), "DRPolicy deleted prematurely, with active DRPC references")
 }
 
 func ensureDRPolicyIsDeleted(drpolicyName string) {
@@ -1326,7 +1326,7 @@ func verifyUserPlacementRuleDecisionUnchanged(name, namespace, homeCluster strin
 		placementObj = usrPlRule
 
 		return err == nil && usrPlRule.Status.Decisions[0].ClusterName == homeCluster
-	}, timeout, interval).Should(BeTrue())
+	}).Should(BeTrue())
 
 	Expect(placementObj.GetAnnotations()[controllers.DRPCNameAnnotation]).Should(Equal(DRPCCommonName))
 	Expect(placementObj.GetAnnotations()[controllers.DRPCNamespaceAnnotation]).Should(Equal(namespace))

--- a/controllers/suite_test.go
+++ b/controllers/suite_test.go
@@ -114,6 +114,7 @@ func createOperatorNamespace(ramenNamespace string) {
 var _ = BeforeSuite(func() {
 	// onsi.github.io/gomega/#adjusting-output
 	format.MaxLength = 0
+	SetDefaultConsistentlyDuration(1 * time.Second)
 	testLogger = zap.New(zap.UseFlagOptions(&zap.Options{
 		Development: true,
 		DestWriter:  GinkgoWriter,

--- a/controllers/volsync/volsync_suite_test.go
+++ b/controllers/volsync/volsync_suite_test.go
@@ -8,6 +8,7 @@ import (
 	"os"
 	"path/filepath"
 	"testing"
+	"time"
 
 	"github.com/go-logr/logr"
 	. "github.com/onsi/ginkgo/v2"
@@ -64,6 +65,8 @@ func TestVolsync(t *testing.T) {
 }
 
 var _ = BeforeSuite(func() {
+	SetDefaultConsistentlyDuration(1 * time.Second)
+	SetDefaultConsistentlyPollingInterval(250 * time.Millisecond)
 	logger = zap.New(zap.UseFlagOptions(&zap.Options{
 		Development: true,
 		DestWriter:  GinkgoWriter,

--- a/controllers/volsync/vshandler_test.go
+++ b/controllers/volsync/vshandler_test.go
@@ -477,7 +477,7 @@ var _ = Describe("VolSync_Handler", func() {
 					Consistently(func() error {
 						return k8sClient.Get(ctx,
 							types.NamespacedName{Name: rdSpec.ProtectedPVC.Name, Namespace: testNamespace.GetName()}, createdRD)
-					}, 1*time.Second, interval).ShouldNot(BeNil())
+					}).ShouldNot(BeNil())
 				})
 			})
 
@@ -719,7 +719,7 @@ var _ = Describe("VolSync_Handler", func() {
 					Consistently(func() error {
 						return k8sClient.Get(ctx,
 							types.NamespacedName{Name: rsSpec.ProtectedPVC.Name, Namespace: testNamespace.GetName()}, createdRS)
-					}, 1*time.Second, interval).ShouldNot(BeNil())
+					}).ShouldNot(BeNil())
 				})
 			})
 
@@ -759,7 +759,7 @@ var _ = Describe("VolSync_Handler", func() {
 						Consistently(func() error {
 							return k8sClient.Get(ctx,
 								types.NamespacedName{Name: rsSpec.ProtectedPVC.Name, Namespace: testNamespace.GetName()}, createdRS)
-						}, 1*time.Second, interval).ShouldNot(BeNil())
+						}).ShouldNot(BeNil())
 					})
 				})
 
@@ -781,7 +781,7 @@ var _ = Describe("VolSync_Handler", func() {
 						Consistently(func() error {
 							return k8sClient.Get(ctx,
 								types.NamespacedName{Name: rsSpec.ProtectedPVC.Name, Namespace: testNamespace.GetName()}, createdRS)
-						}, 1*time.Second, interval).ShouldNot(BeNil())
+						}).ShouldNot(BeNil())
 					})
 				})
 
@@ -804,7 +804,7 @@ var _ = Describe("VolSync_Handler", func() {
 						Consistently(func() error {
 							return k8sClient.Get(ctx,
 								types.NamespacedName{Name: rsSpec.ProtectedPVC.Name, Namespace: testNamespace.GetName()}, createdRS)
-						}, 1*time.Second, interval).ShouldNot(BeNil())
+						}).ShouldNot(BeNil())
 					})
 				})
 

--- a/controllers/vrg_volrep_test.go
+++ b/controllers/vrg_volrep_test.go
@@ -1591,7 +1591,7 @@ func (v *vrgTest) verifyVRGStatusCondition(conditionName string, expectedStatus 
 		Eventually(testFunc, vrgtimeout, vrginterval).Should(BeTrue(),
 			"while waiting for VRG %s TRUE condition %s/%s", conditionName, v.vrgName, v.namespace)
 	default: // false
-		Consistently(testFunc, vrgtimeout, vrginterval).Should(BeTrue(),
+		Consistently(testFunc).Should(BeTrue(),
 			"while waiting for VRG %s FALSE condition %s/%s", conditionName, v.vrgName, v.namespace)
 	}
 }


### PR DESCRIPTION
Some Ramen tests use the same Consistently duration as Eventually timeouts. The Eventually timeout is a maximum wait time, while the Consistently duration is a minimum wait time.