### PR TITLE
Test drpc delete on placementRule delete

### DIFF
--- a/internal/controller/drplacementcontrol_controller_test.go
+++ b/internal/controller/drplacementcontrol_controller_test.go
@@ -1852,6 +1852,31 @@ var _ = Describe("DRPlacementControl Reconciler Errors", func() {
 			}
 		}, SpecTimeout(time.Second*10))
 	})
+        When("a placementRule is deleted", func() {
+		AfterEach(func() {
+			err := forceCleanupClusterAfterAErrorTest()
+			Expect(err).ToNot(HaveOccurred())
+		})
+		It("drpc should get deleted", func(ctx SpecContext) {
+			_, _ = InitialDeploymentAsync(DefaultDRPCNamespace, UserPlacementRuleName, East1ManagedCluster,
+				UsePlacementRule)
+			waitForCompletion(string(rmn.Deployed))
+
+			deleteUserPlacementRule(UserPlacementRuleName, DefaultDRPCNamespace)
+
+			Eventually(func() bool {
+				drpcLookupKey := types.NamespacedName{
+					Name:      DRPCCommonName,
+					Namespace: DefaultDRPCNamespace,
+				}
+				latestDRPC := &rmn.DRPlacementControl{}
+
+				err := apiReader.Get(context.TODO(), drpcLookupKey, latestDRPC)
+
+				return errors.IsNotFound(err)
+			}, timeout, interval).Should(HaveOccurred())
+		}, SpecTimeout(time.Second*10))
+	})
 })
 
 // +kubebuilder:docs-gen:collapse=Imports


### PR DESCRIPTION
When a placementRule is deleted, then we processDeletion() for the DRPC that has the PlacementRule as its placement object. However, we don't delete the DRPC itself.

This PR is to start the conversation on this topic and decide if we want to issue a delete for the DRPC itself in such cases.