### PR TITLE
e2e: enabled cephfs discovered

### DIFF
--- a/e2e/deployers/discoveredapps.go
+++ b/e2e/deployers/discoveredapps.go
@@ -115,5 +115,5 @@ func (d DiscoveredApps) Undeploy(ctx types.Context) error {
 }
 
 func (d DiscoveredApps) IsWorkloadSupported(w types.Workload) bool {
-	return w.GetName() != "Deploy-cephfs"
+	return true
 }

--- a/e2e/dractions/actionsdiscoveredapps.go
+++ b/e2e/dractions/actionsdiscoveredapps.go
@@ -131,7 +131,7 @@ func failoverRelocateDiscoveredApps(ctx types.Context, action ramen.DRAction) er
 		return err
 	}
 
-	if err := waitDRPCProgression(ctx, client, namespace, name, ramen.ProgressionWaitOnUserToCleanUp); err != nil {
+	if err := waitDRPCProgression(ctx, client, namespace, name, ramen.ProgressionWaitOnUserToCleanUp, true); err != nil {
 		return err
 	}
 
@@ -142,7 +142,7 @@ func failoverRelocateDiscoveredApps(ctx types.Context, action ramen.DRAction) er
 		return err
 	}
 
-	if err = waitDRPCProgression(ctx, client, namespace, name, ramen.ProgressionCompleted); err != nil {
+	if err = waitDRPCProgression(ctx, client, namespace, name, ramen.ProgressionCompleted, false); err != nil {
 		return err
 	}
 

--- a/e2e/dractions/retry.go
+++ b/e2e/dractions/retry.go
@@ -200,7 +200,7 @@ func waitDRPCProgression(
 	ctx types.Context,
 	client client.Client,
 	namespace, name string,
-	progression ramen.ProgressionStatus,
+	progression ramen.ProgressionStatus, consistently bool
 ) error {
 	log := ctx.Logger()
 	startTime := time.Now()


### PR DESCRIPTION
For discovered apps, we want user to perform the cleanup of the workload. We should advertise the progression to them at the same time when we ask OCM/ACM to perform the cleanup.