### PR TITLE
e2e: Add ClusterSet validation

### DIFF
--- a/e2e/util/clusterset.go
+++ b/e2e/util/clusterset.go
@@ -1,0 +1,46 @@
+// SPDX-FileCopyrightText: The RamenDR authors
+// SPDX-License-Identifier: Apache-2.0
+
+package util
+
+import (
+	"context"
+	"fmt"
+
+	ocmv1 "open-cluster-management.io/api/cluster/v1"
+	ocmv1b2 "open-cluster-management.io/api/cluster/v1beta2"
+	"sigs.k8s.io/controller-runtime/pkg/client"
+
+	"github.com/ramendr/ramen/e2e/types"
+)
+
+func GetClusterSet(hub types.Cluster, clusterSetName string) (*ocmv1b2.ManagedClusterSet, error) {
+	clusterSet := &ocmv1b2.ManagedClusterSet{}
+	key := client.ObjectKey{Name: clusterSetName}
+
+	if err := hub.Client.Get(context.TODO(), key, clusterSet); err != nil {
+		return nil, fmt.Errorf("failed to get ClusterSet %q: %w", clusterSetName, err)
+	}
+
+	return clusterSet, nil
+}
+
+func GetManagedClustersFromClusterSet(hub types.Cluster, clusterSetName string) ([]string, error) {
+	clusterList := &ocmv1.ManagedClusterList{}
+	labelSelector := client.MatchingLabels{"cluster.open-cluster-management.io/clusterset": clusterSetName}
+
+	if err := hub.Client.List(context.TODO(), clusterList, labelSelector); err != nil {
+		return nil, fmt.Errorf("failed to list ManagedClusters for ClusterSet %q: %w", clusterSetName, err)
+	}
+
+	if len(clusterList.Items) == 0 {
+		return nil, fmt.Errorf("no clusters found for ClusterSet %q", clusterSetName)
+	}
+
+	clusterNames := make([]string, 0, len(clusterList.Items))
+	for _, cluster := range clusterList.Items {
+		clusterNames = append(clusterNames, cluster.Name)
+	}
+
+	return clusterNames, nil
+}

--- a/e2e/validate/validation.go
+++ b/e2e/validate/validation.go
@@ -126,6 +126,9 @@ func TestConfig(env *types.Env, config *types.Config, log *zap.SugaredLogger) er
 		return fmt.Errorf("failed to validate test config: %w", err)
 	}
 
+	if err := clustersInClusterSet(env, config, log); err != nil {
+		return fmt.Errorf("failed to validate test config: %w", err)
+	}
 	return nil
 }
 
@@ -148,6 +151,32 @@ func clustersInDRPolicy(env *types.Env, config *types.Config, log *zap.SugaredLo
 	}
 
 	log.Infof("Validated clusters [%q, %q] in DRPolicy %q", clusters[0].Name, clusters[1].Name, config.DRPolicy)
+
+	return nil
+}
+
+// clustersInClusterSet checks if configured clusters exists in configured clusterset.
+// Returns an error if provided cluster names are not the same as managedclusters in clusterset.
+// The reason for a failure may be wrong cluster name or wrong clusterset.
+func clustersInClusterSet(env *types.Env, config *types.Config, log *zap.SugaredLogger) error {
+	if _, err := util.GetClusterSet(env.Hub, config.ClusterSet); err != nil {
+		return err
+	}
+
+	clusterNames, err := util.GetManagedClustersFromClusterSet(env.Hub, config.ClusterSet)
+	if err != nil {
+		return err
+	}
+
+	clusters := []types.Cluster{env.C1, env.C2}
+	for _, cluster := range clusters {
+		if !slices.Contains(clusterNames, cluster.Name) {
+			return fmt.Errorf("cluster %q is not defined in ClusterSet %q, clusters in ClusterSet: %q",
+				cluster.Name, config.ClusterSet, clusterNames)
+		}
+	}
+
+	log.Infof("Validated clusters [%q, %q] in ClusterSet %q", clusters[0].Name, clusters[1].Name, config.ClusterSet)
 
 	return nil
 }


### PR DESCRIPTION
Added clustersInClusterSet function to validate that the configured clusters exist in the specified ClusterSet. Ensures test config validation fails early if the ClusterSet is misconfigured or the clusters are not part of it.