### PR TITLE
Validates clusterID field of DRClusterConfig

### DIFF
--- a/config/rbac/role.yaml
+++ b/config/rbac/role.yaml
@@ -32,6 +32,16 @@ rules:
   - watch
 - apiGroups:
   - ""
+  resourceNames:
+  - kube-system
+  resources:
+  - namespaces
+  verbs:
+  - get
+  - list
+  - watch
+- apiGroups:
+  - ""
   resources:
   - persistentvolumeclaims
   - secrets

--- a/internal/controller/controllers_utils_test.go
+++ b/internal/controller/controllers_utils_test.go
@@ -8,6 +8,8 @@ import (
 	"fmt"
 	"time"
 
+	corev1 "k8s.io/api/core/v1"
+
 	. "github.com/onsi/gomega"
 	. "github.com/onsi/gomega/gstruct"
 	gomegaTypes "github.com/onsi/gomega/types"
@@ -55,6 +57,12 @@ func createManagedCluster(k8sClient client.Client, cluster string) *ocmv1.Manage
 }
 
 func updateManagedClusterStatus(k8sClient client.Client, mc *ocmv1.ManagedCluster) {
+	ns := &corev1.Namespace{}
+	Expect(k8sClient.Get(context.TODO(), types.NamespacedName{
+		Namespace: "",
+		Name:      "kube-system",
+	}, ns)).To(Succeed())
+
 	mc.Status = ocmv1.ManagedClusterStatus{
 		Conditions: []metav1.Condition{
 			{
@@ -68,7 +76,7 @@ func updateManagedClusterStatus(k8sClient client.Client, mc *ocmv1.ManagedCluste
 		ClusterClaims: []ocmv1.ManagedClusterClaim{
 			{
 				Name:  "id.k8s.io",
-				Value: "fake",
+				Value: fmt.Sprint(ns.ObjectMeta.UID),
 			},
 		},
 	}

--- a/internal/controller/drcluster_controller.go
+++ b/internal/controller/drcluster_controller.go
@@ -353,6 +353,7 @@ func filterDRClusterSecret(ctx context.Context, reader client.Reader, secret *co
 // +kubebuilder:rbac:groups=argoproj.io,resources=applicationsets,verbs=get;list;watch
 // +kubebuilder:rbac:groups="",resources=secrets,verbs=list;watch
 // +kubebuilder:rbac:groups="",resources=configmaps,verbs=list;watch
+// +kubebuilder:rbac:groups="",resources=namespaces,resourceNames=kube-system,verbs=get;list;watch
 
 func (r *DRClusterReconciler) Reconcile(ctx context.Context, req ctrl.Request) (ctrl.Result, error) {
 	// TODO: Validate managedCluster name? and also ensure it is not deleted!
@@ -653,6 +654,21 @@ func (u *drclusterInstance) ensureDRClusterConfig() error {
 	return nil
 }
 
+// getK8sClusterID getClusterID returns the cluster ID of the k8s Cluster
+func (u *drclusterInstance) getK8sClusterID() string {
+	kubeSystemNamespace := &corev1.Namespace{}
+	if err := u.client.Get(u.ctx, types.NamespacedName{
+		Name:      "kube-system",
+		Namespace: "",
+	}, kubeSystemNamespace); err != nil {
+		u.log.Error(err, "Failed to get the namespace kube-system")
+
+		return ""
+	}
+
+	return fmt.Sprint(kubeSystemNamespace.GetObjectMeta().GetUID())
+}
+
 //nolint:funlen
 func (u *drclusterInstance) generateDRClusterConfig() (*ramen.DRClusterConfig, error) {
 	mc, err := util.NewManagedClusterInstance(u.ctx, u.client, u.object.GetName())
@@ -663,6 +679,10 @@ func (u *drclusterInstance) generateDRClusterConfig() (*ramen.DRClusterConfig, e
 	clusterID, err := mc.ClusterID()
 	if err != nil {
 		return nil, err
+	}
+
+	if clusterID != u.getK8sClusterID() {
+		return nil, fmt.Errorf("cluster ID claim value %v differs from that of the k8s cluster", clusterID)
 	}
 
 	drcConfig := ramen.DRClusterConfig{
@@ -680,13 +700,21 @@ func (u *drclusterInstance) generateDRClusterConfig() (*ramen.DRClusterConfig, e
 
 	core.ObjectCreatedByRamenSetLabel(&drcConfig)
 
-	drpolicies, err := util.GetAllDRPolicies(u.ctx, u.reconciler.APIReader)
+	err = u.ensureNoDuplicateSchedules(&drcConfig)
 	if err != nil {
 		return nil, err
 	}
+	return &drcConfig, nil
+}
 
-	// Ensure that schedules are not duplicated by, storing them in "added" to avoid adding a duplicate schedule from
-	// another DRPolicy
+// ensureNoDuplicateSchedules ensures that schedules are not duplicated by, storing them in "added" to avoid adding a duplicate
+// schedule from another DRPolicy
+func (u *drclusterInstance) ensureNoDuplicateSchedules(drcConfig *ramen.DRClusterConfig) error {
+	drpolicies, err := util.GetAllDRPolicies(u.ctx, u.reconciler.APIReader)
+	if err != nil {
+		return err
+	}
+
 	added := map[string]bool{}
 
 	for idx := range drpolicies.Items {
@@ -713,7 +741,7 @@ func (u *drclusterInstance) generateDRClusterConfig() (*ramen.DRClusterConfig, e
 		}
 	}
 
-	return &drcConfig, nil
+	return nil
 }
 
 // TODO:

--- a/internal/controller/drcluster_drcconfig_test.go
+++ b/internal/controller/drcluster_drcconfig_test.go
@@ -6,8 +6,11 @@ package controllers_test
 import (
 	"context"
 	"os"
+	"fmt"
 	"path/filepath"
 	"time"
+
+	"k8s.io/apimachinery/pkg/types"
 
 	. "github.com/onsi/ginkgo/v2"
 	. "github.com/onsi/gomega"
@@ -43,6 +46,7 @@ var _ = Describe("DRCluster-DRClusterConfigTests", Ordered, func() {
 		drCluster1Name = "drcluster1"
 		ramenConfig    *ramen.RamenConfig
 		mc             *ocmv1.ManagedCluster
+		cid            string
 	)
 
 	BeforeAll(func() {
@@ -339,6 +343,12 @@ var _ = Describe("DRCluster-DRClusterConfigTests", Ordered, func() {
 			When("ManagedCluster resource has all required status", func() {
 				It("reports DRCluster validated as true", func() {
 					By("updating a ManagedCluster resource status with correct claims")
+					ns := &corev1.Namespace{}
+					Expect(k8sClient.Get(context.TODO(), types.NamespacedName{
+						Namespace: "",
+						Name:      "kube-system",
+					}, ns)).To(Succeed())
+					cid = fmt.Sprint(ns.ObjectMeta.UID)
 					mc.Status = ocmv1.ManagedClusterStatus{
 						Conditions: []metav1.Condition{
 							{
@@ -367,7 +377,7 @@ var _ = Describe("DRCluster-DRClusterConfigTests", Ordered, func() {
 							},
 							{
 								Name:  "id.k8s.io",
-								Value: "cluster",
+								Value: cid,
 							},
 						},
 					}
@@ -387,7 +397,7 @@ var _ = Describe("DRCluster-DRClusterConfigTests", Ordered, func() {
 					)
 				})
 				It("creates the DRClusterConfig manifest", func() {
-					verifyDRClusterConfigMW(k8sClient, drCluster1Name, "cluster", []string{}, false)
+					verifyDRClusterConfigMW(k8sClient, drCluster1Name, cid, []string{}, false)
 				})
 			})
 		})
@@ -409,7 +419,7 @@ var _ = Describe("DRCluster-DRClusterConfigTests", Ordered, func() {
 					}
 					Expect(k8sClient.Create(context.TODO(), &syncDRPolicy)).To(Succeed())
 
-					verifyDRClusterConfigMW(k8sClient, drCluster1Name, "cluster", []string{}, true)
+					verifyDRClusterConfigMW(k8sClient, drCluster1Name, cid, []string{}, true)
 				})
 			})
 			When("There is an Async DRPolicy", func() {
@@ -429,7 +439,7 @@ var _ = Describe("DRCluster-DRClusterConfigTests", Ordered, func() {
 					}
 					Expect(k8sClient.Create(context.TODO(), &asyncDRPolicy)).To(Succeed())
 
-					verifyDRClusterConfigMW(k8sClient, drCluster1Name, "cluster", []string{"1m"}, false)
+					verifyDRClusterConfigMW(k8sClient, drCluster1Name, cid, []string{"1m"}, false)
 				})
 			})
 			When("There is another Async DRPolicy with the same schedule", func() {
@@ -449,7 +459,7 @@ var _ = Describe("DRCluster-DRClusterConfigTests", Ordered, func() {
 					}
 					Expect(k8sClient.Create(context.TODO(), &asyncDRPolicy)).To(Succeed())
 
-					verifyDRClusterConfigMW(k8sClient, drCluster1Name, "cluster", []string{"1m"}, true)
+					verifyDRClusterConfigMW(k8sClient, drCluster1Name, cid, []string{"1m"}, true)
 				})
 			})
 			When("There is another Async DRPolicy with a different schedule", func() {
@@ -469,7 +479,7 @@ var _ = Describe("DRCluster-DRClusterConfigTests", Ordered, func() {
 					}
 					Expect(k8sClient.Create(context.TODO(), &asyncDRPolicy)).To(Succeed())
 
-					verifyDRClusterConfigMW(k8sClient, drCluster1Name, "cluster", []string{"1m", "5m"}, false)
+					verifyDRClusterConfigMW(k8sClient, drCluster1Name, cid, []string{"1m", "5m"}, false)
 				})
 			})
 			When("An Async DRPolicy with a common schedule is deleted", func() {
@@ -482,7 +492,7 @@ var _ = Describe("DRCluster-DRClusterConfigTests", Ordered, func() {
 					}
 					Expect(k8sClient.Delete(context.TODO(), &asyncDRPolicy)).To(Succeed())
 
-					verifyDRClusterConfigMW(k8sClient, drCluster1Name, "cluster", []string{"1m", "5m"}, true)
+					verifyDRClusterConfigMW(k8sClient, drCluster1Name, cid, []string{"1m", "5m"}, true)
 				})
 			})
 			When("An Async DRPolicy with a unique schedule is deleted", func() {
@@ -495,7 +505,7 @@ var _ = Describe("DRCluster-DRClusterConfigTests", Ordered, func() {
 					}
 					Expect(k8sClient.Delete(context.TODO(), &asyncDRPolicy)).To(Succeed())
 
-					verifyDRClusterConfigMW(k8sClient, drCluster1Name, "cluster", []string{"1m"}, false)
+					verifyDRClusterConfigMW(k8sClient, drCluster1Name, cid, []string{"1m"}, false)
 				})
 			})
 			When("A last Async DRPolicy with a unique schedule is deleted", func() {
@@ -508,7 +518,7 @@ var _ = Describe("DRCluster-DRClusterConfigTests", Ordered, func() {
 					}
 					Expect(k8sClient.Delete(context.TODO(), &asyncDRPolicy)).To(Succeed())
 
-					verifyDRClusterConfigMW(k8sClient, drCluster1Name, "cluster", []string{}, false)
+					verifyDRClusterConfigMW(k8sClient, drCluster1Name, cid, []string{}, false)
 				})
 			})
 			When("An Async DRPolicy does not contain the DRCluster", func() {
@@ -528,7 +538,7 @@ var _ = Describe("DRCluster-DRClusterConfigTests", Ordered, func() {
 					}
 					Expect(k8sClient.Create(context.TODO(), &asyncDRPolicy)).To(Succeed())
 
-					verifyDRClusterConfigMW(k8sClient, drCluster1Name, "cluster", []string{}, true)
+					verifyDRClusterConfigMW(k8sClient, drCluster1Name, cid, []string{}, true)
 				})
 			})
 			When("There are no DRPolicy resources containing the DRCluster", func() {
@@ -541,7 +551,7 @@ var _ = Describe("DRCluster-DRClusterConfigTests", Ordered, func() {
 					}
 					Expect(k8sClient.Delete(context.TODO(), &syncDRPolicy)).To(Succeed())
 
-					verifyDRClusterConfigMW(k8sClient, drCluster1Name, "cluster", []string{}, true)
+					verifyDRClusterConfigMW(k8sClient, drCluster1Name, cid, []string{}, true)
 				})
 			})
 			When("There are no DRPolicy resources", func() {
@@ -554,7 +564,7 @@ var _ = Describe("DRCluster-DRClusterConfigTests", Ordered, func() {
 					}
 					Expect(k8sClient.Delete(context.TODO(), &asyncDRPolicy)).To(Succeed())
 
-					verifyDRClusterConfigMW(k8sClient, drCluster1Name, "cluster", []string{}, true)
+					verifyDRClusterConfigMW(k8sClient, drCluster1Name, cid, []string{}, true)
 				})
 			})
 		})

--- a/internal/controller/drclusterconfig_controller_test.go
+++ b/internal/controller/drclusterconfig_controller_test.go
@@ -6,9 +6,12 @@ package controllers_test
 import (
 	"context"
 	"os"
+	"fmt"
 	"path/filepath"
 	"slices"
 	"time"
+
+	v1 "k8s.io/api/core/v1"
 
 	volrep "github.com/csi-addons/kubernetes-csi-addons/api/replication.storage/v1alpha1"
 	snapv1 "github.com/kubernetes-csi/external-snapshotter/client/v8/apis/volumesnapshot/v1"
@@ -136,9 +139,17 @@ var _ = Describe("DRClusterConfig-ClusterClaimsTests", Ordered, func() {
 
 		By("Creating a DClusterConfig")
 
+		ns := &v1.Namespace{}
+		Expect(k8sClient.Get(context.TODO(), types.NamespacedName{
+			Namespace: "",
+			Name:      "kube-system",
+		}, ns)).To(Succeed())
+
 		drCConfig = &ramen.DRClusterConfig{
 			ObjectMeta: metav1.ObjectMeta{Name: "local"},
-			Spec:       ramen.DRClusterConfigSpec{ClusterID: "local-cid"},
+			Spec: ramen.DRClusterConfigSpec{
+				ClusterID: fmt.Sprint(ns.ObjectMeta.UID),
+			},
 		}
 		Expect(k8sClient.Create(context.TODO(), drCConfig)).To(Succeed())
 		objectConditionExpectEventually(


### PR DESCRIPTION
Validates clusterID fetched from managed cluster's claim matches that of the cluster (differs for ocp/k8s). Refactors generateDRClusterConfig to avoid cyclomatic complexity exceeding its limit