### PR TITLE
recipe: add max retries for recipe and stop option

### DIFF
--- a/internal/controller/hooks/exec_hook.go
+++ b/internal/controller/hooks/exec_hook.go
@@ -96,7 +96,6 @@ func (e ExecHook) executeInverseOp(inverseOp string, log logr.Logger) {
 }
 
 func shouldInverseOpBeExecuted(inverseOp string, hookSpec *kubeobjects.HookSpec, err error) bool {
-	// TODO: shouldOpHookBeFailedOnError to be used?
 	return err != nil && inverseOp != "" && shouldOpHookBeFailedOnError(hookSpec)
 }
 

--- a/internal/controller/util/recipe.go
+++ b/internal/controller/util/recipe.go
@@ -10,12 +10,17 @@ import (
 )
 
 type RecipeElements struct {
-	PvcSelector      PvcSelector
-	CaptureWorkflow  []kubeobjects.CaptureSpec
-	RecoverWorkflow  []kubeobjects.RecoverSpec
-	CaptureFailOn    string
-	RestoreFailOn    string
-	RecipeWithParams *recipev1.Recipe
+	PvcSelector         PvcSelector
+	CaptureWorkflow     []kubeobjects.CaptureSpec
+	RecoverWorkflow     []kubeobjects.RecoverSpec
+	CaptureFailOn       string
+	RestoreFailOn       string
+	RecipeWithParams    *recipev1.Recipe
+	StopRecipeReconcile bool
+}
+
+type RecipeStatus struct {
+	Attempts int
 }
 
 type PvcSelector struct {

--- a/internal/controller/volumereplicationgroup_controller.go
+++ b/internal/controller/volumereplicationgroup_controller.go
@@ -57,6 +57,7 @@ type VolumeReplicationGroupReconciler struct {
 	kubeObjects         kubeobjects.RequestsManager
 	RateLimiter         *workqueue.TypedRateLimiter[reconcile.Request]
 	veleroCRsAreWatched bool
+	recipeStatus        map[string]*util.RecipeStatus
 }
 
 // SetupWithManager sets up the controller with the Manager.


### PR DESCRIPTION
Add max retries for processing a recipe. By default 10 max retries can be done. VRG reconcile will hold the memory of number of retries for each recipe.